### PR TITLE
Shl by default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,16 +32,16 @@
 //! use bittle::Bits;
 //!
 //! let array: [u32; 4] = [0, 1, 2, 3];
-//! assert!(array.iter_ones().eq([63, 94, 126, 127]));
+//! assert!(array.iter_ones().eq([32, 65, 96, 97]));
 //!
-//! let n = 0b10001000_00000000_00000000_00000000u32;
+//! let n = 0b00000000_00000000_00000000_00010001u32;
 //! assert!(n.iter_ones().eq([0, 4]));
 //!
-//! let array_of_arrays: [[u8; 4]; 2] = [[8, 0, 0, 0], [0, 0, 128, 0]];
+//! let array_of_arrays: [[u8; 4]; 2] = [[16, 0, 0, 0], [0, 0, 1, 0]];
 //! assert!(array_of_arrays.iter_ones().eq([4, 48]));
 //!
 //! let mut vec: Vec<u32> = vec![0, 1, 2, 3];
-//! assert!(vec.iter_ones().eq([63, 94, 126, 127]));
+//! assert!(vec.iter_ones().eq([32, 65, 96, 97]));
 //! ```
 //!
 //! <br>
@@ -52,14 +52,14 @@
 //! ```
 //! use bittle::Bits;
 //!
-//! let array: [u32; 4] = bittle::set![63, 94, 126, 127];
-//! assert!(array.iter_ones().eq([63, 94, 126, 127]));
-//!
-//! let array_of_arrays: [[u8; 4]; 2] = bittle::set![4, 48];
-//! assert!(array_of_arrays.iter_ones().eq([4, 48]));
+//! let array: [u32; 4] = bittle::set![32, 65, 96, 97];
+//! assert!(array.iter_ones().eq([32, 65, 96, 97]));
 //!
 //! let n: u32 = bittle::set![0, 4];
 //! assert!(n.iter_ones().eq([0, 4]));
+//!
+//! let array_of_arrays: [[u8; 4]; 2] = bittle::set![4, 48];
+//! assert!(array_of_arrays.iter_ones().eq([4, 48]));
 //! ```
 //!
 //! <br>
@@ -71,11 +71,12 @@
 //! use bittle::{Bits, BitsMut};
 //!
 //! let mut vec: Vec<u32> = vec![0u32; 4];
-//! vec.set_bit(63);
-//! vec.set_bit(94);
-//! vec.set_bit(126);
-//! vec.set_bit(127);
-//! assert!(vec.iter_ones().eq([63, 94, 126, 127]));
+//! vec.set_bit(32);
+//! vec.set_bit(65);
+//! vec.set_bit(96);
+//! vec.set_bit(97);
+//! assert!(vec.iter_ones().eq([32, 65, 96, 97]));
+//! assert_eq!(vec, [0, 1, 2, 3]);
 //! ```
 //!
 //! <br>

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -7,7 +7,7 @@
 ///
 /// let mask: u8 = bittle::set![0, 1, 3];
 /// assert!(mask.iter_ones().eq([0, 1, 3]));
-/// assert_eq!(mask, 0b11010000);
+/// assert_eq!(mask, 0b00001011);
 /// ```
 #[macro_export]
 macro_rules! set {

--- a/src/set.rs
+++ b/src/set.rs
@@ -22,7 +22,7 @@ use crate::bits_owned::BitsOwned;
 /// use bittle::{Bits, Set};
 ///
 /// let set: u128 = bittle::set![1, 14];
-/// assert_eq!(format!("{set:?}"), "85080976323951685521100712850600493056");
+/// assert_eq!(format!("{set:?}"), "16386");
 ///
 /// let set: Set<u128> = Set::new(set);
 /// assert_eq!(format!("{set:?}"), "{1, 14}");
@@ -39,8 +39,8 @@ use crate::bits_owned::BitsOwned;
 /// ```
 /// use bittle::Set;
 ///
-/// let array = [0b00010000u8, 0b0u8];
-/// assert!(array.into_iter().eq([16, 0]));
+/// let array = [0b00001000u8, 0b0u8];
+/// assert!(array.into_iter().eq([8, 0]));
 ///
 /// let set = Set::new(array);
 /// assert!(set.into_iter().eq([3]));
@@ -88,14 +88,14 @@ use crate::bits_owned::BitsOwned;
 ///
 /// ```
 /// use bittle::Set;
-/// let a = 0b00001000_10000000_00000000_00000000u32;
-/// let b = 0b00001000_10000000u16;
-/// let c = vec![0b00001000u8, 0b10000000u8];
+/// let a = 0b00000000_00000000_00000001_00010000u32;
+/// let b = 0b00000001_00010000u16;
+/// let c = vec![0b00010000u8, 0b00000001u8];
 ///
 /// assert_eq!(Set::new(a), Set::new(b));
 /// assert_eq!(Set::new(a), Set::from_ref(&c[..]));
 ///
-/// let d = 0b11111111_10000000u16;
+/// let d = 0b00000001_11111111u16;
 /// assert!(Set::new(d) < Set::new(a));
 /// assert!(Set::new(d) < Set::new(b));
 /// assert!(Set::new(d) < Set::from_ref(&c[..]));
@@ -180,7 +180,7 @@ impl<T> Set<T> {
     /// use bittle::{Bits, Set};
     ///
     /// let mut set = Set::new(0b00001001u32);
-    /// assert!(set.iter_ones().eq([28, 31]));
+    /// assert!(set.iter_ones().eq([0, 3]));
     /// ```
     #[inline]
     pub const fn new(bits: T) -> Self {
@@ -199,7 +199,7 @@ where
     /// ```
     /// use bittle::{Bits, Set};
     ///
-    /// let mut set = Set::from_ref(&[0b10000000u8, 0b00001000u8]);
+    /// let mut set = Set::from_ref(&[0b00000001u8, 0b00010000u8]);
     /// assert!(set.iter_ones().eq([0, 12]));
     /// ```
     #[inline]
@@ -219,13 +219,13 @@ where
     /// ```
     /// use bittle::{Bits, BitsMut, Set};
     ///
-    /// let mut values = [0b10000000u8, 0b00001000u8];
+    /// let mut values = [0b00000001u8, 0b00010000u8];
     ///
     /// let mut set = Set::from_mut(&mut values);
     /// assert!(set.iter_ones().eq([0, 12]));
-    /// set.set_bit(4);
     ///
-    /// assert_eq!(&values[..], &[0b10001000u8, 0b00001000u8]);
+    /// set.set_bit(4);
+    /// assert_eq!(&values[..], &[0b00010001u8, 0b00010000u8]);
     /// ```
     #[inline]
     pub fn from_mut<U>(bits: &mut U) -> &mut Self
@@ -438,7 +438,13 @@ where
 ///
 /// ```
 /// use bittle::Set;
-/// assert_eq!(Set::new(0b00001000u8), Set::new(0b00001000_00000000u16));
+///
+/// let a = Set::new(0b00001000u8);
+/// let b = Set::new(0b00000000_00001000u16);
+/// let c = Set::new([0b00001000u8, 0]);
+///
+/// assert_eq!(a, b);
+/// assert_eq!(a, c);
 /// ```
 impl<T, U> cmp::PartialEq<U> for Set<T>
 where


### PR DESCRIPTION
After some trial and error it seems like using bitsets optimized for shifting left results in better optimizations opportunities, particularly in combination with [automatic vectorization](https://gist.github.com/udoprog/ec85576b1d0baa120b068feb92536ab5) (godbolt: <https://godbolt.org/z/Kre4brrzM>).

The diff shows the difference in assembly for each fn, and after benchmarking the two impls it seems like the former is faster. I couldn't say exactly why, only that it is :). Presumably better vector instructions can be used.

So this library is switching to shl indexing for primitive numbers, with the option of enabling shr behavior by settings `--cfg bittle_shr`. Beware that it might break code unless you make sure you're the only one using it so it should only really be used for experimentation.