### PR TITLE
Support custom shift indexing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,3 @@ jobs:
         override: true
         profile: minimal
     - run: cargo test
-
-  build_shr:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-        profile: minimal
-    - run: cargo test
-      env:
-        RUSTFLAGS: --cfg bittle_shr
-        RUSTDOCFLAGS: --cfg bittle_shr

--- a/README.md
+++ b/README.md
@@ -27,30 +27,17 @@ bittle = "0.5.0"
 ## Guide
 
 A bit is always identified by a [`u32`] by its index, and the exact location
-for primitive numbers is that the least significant bit corresponds to the
-lowest index, and the most significant bit is the highest ([see issue #2]).
-This is called "shift left indexing" and doesn't correspond with what
-literals look like when reading them left-to-right:
+for primitive numbers is defined by its shift indexing mode, which is
+shift-left indexing ([`Shl`]) by default.
+
+Shift-left indexing is constructed increasingly from right to left for
+individual primitives, such as the following [`u8`] literal:
 
 ```text
 0b0010_0010u8
     ^    ^- index 1
     '------ index 5
 ```
-
-It gets a bit more confusing when considering arrays, since each element in
-the array defines a span of bits which does increase left-to-right:
-
-```text
- 0 --------- 8  8 -------- 15
-[0b0010_0010u8, 0b1000_0000u8]
-     ^    ^       ^- index 15
-     |    '--------- index 1
-     '-------------- index 5
-```
-
-> **Note**: shift right indexing is available experimentally under the
-> `--cfg bittle_shr` flag for benchmarking.
 
 <br>
 
@@ -160,10 +147,13 @@ assert!(m.join_ones(&elements).eq([&10, &101]));
 <br>
 
 [`Bits::join_ones`]: https://docs.rs/bittle/latest/bittle/trait.Bits.html#method.join_ones
+[`Bits::test_bit_shr`]: https://docs.rs/bittle/latest/bittle/trait.Bits.html#method.test_bit_shr
+[`Bits::test_bit_with`]: https://docs.rs/bittle/latest/bittle/trait.Bits.html#method.test_bit_with
 [`Bits`]: https://docs.rs/bittle/latest/bittle/trait.Bits.html
 [`BitsMut`]: https://docs.rs/bittle/latest/bittle/trait.BitsMut.html
 [`BitsOwned`]: https://docs.rs/bittle/latest/bittle/trait.BitsOwned.html
 [`Copy`]: https://doc.rust-lang.org/std/marker/trait.Copy.html
 [`set!`]: https://docs.rs/bittle/latest/bittle/macro.set.html
+[`Shl`]: https://docs.rs/bittle/latest/bittle/struct.shl.html
 [`u32`]: https://doc.rust-lang.org/std/primitive.u32.html
 [see issue #2]: https://github.com/udoprog/bittle/pull/2

--- a/src/bits_mut.rs
+++ b/src/bits_mut.rs
@@ -1,4 +1,5 @@
 use crate::bits::Bits;
+use crate::shift::{Shift, Shl, Shr};
 
 /// Bitset mutable operations.
 ///
@@ -34,47 +35,18 @@ pub trait BitsMut: Bits {
     /// Set the given bit.
     ///
     /// Indexes which are out of bounds will wrap around in the bitset.
-    ///
-    /// ```
-    /// use bittle::{Bits, BitsMut, BitsOwned};
-    ///
-    /// let mut a = 0u32;
-    /// assert!(!a.test_bit(32));
-    /// a.set_bit(0);
-    /// assert!(a.test_bit(32));
-    /// a.clear_bit(32);
-    /// assert!(!a.test_bit(0));
-    /// ```
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bittle::{Bits, BitsMut, BitsOwned};
-    ///
-    /// let mut a = u128::ones();
-    ///
-    /// assert!(a.test_bit(0));
-    /// assert!(a.test_bit(1));
-    /// assert!(a.test_bit(127));
-    ///
-    /// a.clear_bit(1);
-    ///
-    /// assert!(a.test_bit(0));
-    /// assert!(!a.test_bit(1));
-    /// assert!(a.test_bit(127));
-    ///
-    /// a.set_bit(1);
-    ///
-    /// assert!(a.test_bit(0));
-    /// assert!(a.test_bit(1));
-    /// assert!(a.test_bit(127));
-    /// ```
-    fn set_bit(&mut self, index: u32);
+    fn set_bit_with<S>(&mut self, index: u32)
+    where
+        S: Shift;
 
-    /// Unset the given bit.
+    /// Set the given bit using [`DefaultShift`].
     ///
     /// Indexes which are out of bounds will wrap around in the bitset.
     ///
+    /// [`DefaultShift`]: crate::DefaultShift
+    ///
+    /// # Examples
+    ///
     /// ```
     /// use bittle::{Bits, BitsMut, BitsOwned};
     ///
@@ -86,7 +58,7 @@ pub trait BitsMut: Bits {
     /// assert!(!a.test_bit(0));
     /// ```
     ///
-    /// # Examples
+    /// Using a bigger set:
     ///
     /// ```
     /// use bittle::{Bits, BitsMut, BitsOwned};
@@ -109,7 +81,154 @@ pub trait BitsMut: Bits {
     /// assert!(a.test_bit(1));
     /// assert!(a.test_bit(127));
     /// ```
-    fn clear_bit(&mut self, index: u32);
+    #[inline]
+    fn set_bit(&mut self, index: u32) {
+        self.set_bit_with::<Shl>(index);
+    }
+
+    /// Set the given bit with [`Shr`].
+    ///
+    /// Indexes which are out of bounds will wrap around in the bitset.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bittle::{Bits, BitsMut, BitsOwned};
+    ///
+    /// let mut a = 0u32;
+    /// assert!(!a.test_bit_shr(32));
+    /// a.set_bit_shr(0);
+    /// assert!(a.test_bit_shr(32));
+    /// a.clear_bit_shr(32);
+    /// assert!(!a.test_bit_shr(0));
+    /// ```
+    ///
+    /// Using a bigger set:
+    ///
+    /// ```
+    /// use bittle::{Bits, BitsMut, BitsOwned};
+    ///
+    /// let mut a = u128::ones();
+    ///
+    /// assert!(a.test_bit_shr(0));
+    /// assert!(a.test_bit_shr(1));
+    /// assert!(a.test_bit_shr(127));
+    ///
+    /// a.clear_bit_shr(1);
+    ///
+    /// assert!(a.test_bit_shr(0));
+    /// assert!(!a.test_bit_shr(1));
+    /// assert!(a.test_bit_shr(127));
+    ///
+    /// a.set_bit_shr(1);
+    ///
+    /// assert!(a.test_bit_shr(0));
+    /// assert!(a.test_bit_shr(1));
+    /// assert!(a.test_bit_shr(127));
+    /// ```
+    #[inline]
+    fn set_bit_shr(&mut self, index: u32) {
+        self.set_bit_with::<Shr>(index);
+    }
+
+    /// Clear the given bit with a custom shift ordering.
+    ///
+    /// Indexes which are out of bounds will wrap around in the bitset.
+    fn clear_bit_with<S>(&mut self, index: u32)
+    where
+        S: Shift;
+
+    /// Clear the given bit using [`DefaultShift`].
+    ///
+    /// Indexes which are out of bounds will wrap around in the bitset.
+    ///
+    /// [`DefaultShift`]: crate::DefaultShift
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bittle::{Bits, BitsMut, BitsOwned};
+    ///
+    /// let mut a = 0u32;
+    /// assert!(!a.test_bit(32));
+    /// a.set_bit(0);
+    /// assert!(a.test_bit(32));
+    /// a.clear_bit(32);
+    /// assert!(!a.test_bit(0));
+    /// ```
+    ///
+    /// Example using array:
+    ///
+    /// ```
+    /// use bittle::{Bits, BitsMut, BitsOwned};
+    ///
+    /// let mut a = u128::ones();
+    ///
+    /// assert!(a.test_bit(0));
+    /// assert!(a.test_bit(1));
+    /// assert!(a.test_bit(127));
+    ///
+    /// a.clear_bit(1);
+    ///
+    /// assert!(a.test_bit(0));
+    /// assert!(!a.test_bit(1));
+    /// assert!(a.test_bit(127));
+    ///
+    /// a.set_bit(1);
+    ///
+    /// assert!(a.test_bit(0));
+    /// assert!(a.test_bit(1));
+    /// assert!(a.test_bit(127));
+    /// ```
+    #[inline]
+    fn clear_bit(&mut self, index: u32) {
+        self.clear_bit_with::<Shl>(index);
+    }
+
+    /// Clear the given bit with [`Shr`].
+    ///
+    /// Indexes which are out of bounds will wrap around in the bitset.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bittle::{Bits, BitsMut, BitsOwned};
+    ///
+    /// let mut a = 0u32;
+    /// assert!(!a.test_bit_shr(32));
+    /// a.set_bit_shr(0);
+    /// assert!(a.test_bit_shr(32));
+    /// a.clear_bit_shr(32);
+    /// assert!(!a.test_bit_shr(0));
+    /// ```
+    ///
+    /// Example using array:
+    ///
+    /// ```
+    /// use bittle::{Bits, BitsMut, BitsOwned};
+    ///
+    /// let mut a = u128::ones();
+    ///
+    /// assert!(a.test_bit_shr(0));
+    /// assert!(a.test_bit_shr(1));
+    /// assert!(a.test_bit_shr(127));
+    ///
+    /// a.clear_bit_shr(1);
+    ///
+    /// assert!(a.test_bit_shr(0));
+    /// assert!(!a.test_bit_shr(1));
+    /// assert!(a.test_bit_shr(127));
+    ///
+    /// a.set_bit_shr(1);
+    ///
+    /// assert!(a.test_bit_shr(0));
+    /// assert!(a.test_bit_shr(1));
+    /// assert!(a.test_bit_shr(127));
+    /// ```
+    #[inline]
+    fn clear_bit_shr(&mut self, index: u32) {
+        self.clear_bit_with::<Shr>(index);
+    }
 
     /// Clear the entire bit pattern.
     ///
@@ -296,8 +415,24 @@ where
     T: ?Sized + BitsMut,
 {
     #[inline]
+    fn set_bit_with<S>(&mut self, index: u32)
+    where
+        S: Shift,
+    {
+        (**self).set_bit_with::<S>(index);
+    }
+
+    #[inline]
     fn set_bit(&mut self, index: u32) {
         (**self).set_bit(index);
+    }
+
+    #[inline]
+    fn clear_bit_with<S>(&mut self, index: u32)
+    where
+        S: Shift,
+    {
+        (**self).clear_bit_with::<S>(index);
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,30 +25,17 @@
 //! ## Guide
 //!
 //! A bit is always identified by a [`u32`] by its index, and the exact location
-//! for primitive numbers is that the least significant bit corresponds to the
-//! lowest index, and the most significant bit is the highest ([see issue #2]).
-//! This is called "shift left indexing" and doesn't correspond with what
-//! literals look like when reading them left-to-right:
+//! for primitive numbers is defined by its shift indexing mode, which is
+//! shift-left indexing ([`Shl`]) by default.
+//!
+//! Shift-left indexing is constructed increasingly from right to left for
+//! individual primitives, such as the following [`u8`] literal:
 //!
 //! ```text
 //! 0b0010_0010u8
 //!     ^    ^- index 1
 //!     '------ index 5
 //! ```
-//!
-//! It gets a bit more confusing when considering arrays, since each element in
-//! the array defines a span of bits which does increase left-to-right:
-//!
-//! ```text
-//!  0 --------- 8  8 -------- 15
-//! [0b0010_0010u8, 0b1000_0000u8]
-//!      ^    ^       ^- index 15
-//!      |    '--------- index 1
-//!      '-------------- index 5
-//! ```
-//!
-//! > **Note**: shift right indexing is available experimentally under the
-//! > `--cfg bittle_shr` flag for benchmarking.
 //!
 //! <br>
 //!
@@ -60,19 +47,15 @@
 //! use bittle::Bits;
 //!
 //! let array: [u32; 4] = [0, 1, 2, 3];
-//! # #[cfg(not(bittle_shr))]
 //! assert!(array.iter_ones().eq([32, 65, 96, 97]));
 //!
 //! let n = 0b00000000_00000000_00000000_00010001u32;
-//! # #[cfg(not(bittle_shr))]
 //! assert!(n.iter_ones().eq([0, 4]));
 //!
 //! let array_of_arrays: [[u8; 4]; 2] = [[16, 0, 0, 0], [0, 0, 1, 0]];
-//! # #[cfg(not(bittle_shr))]
 //! assert!(array_of_arrays.iter_ones().eq([4, 48]));
 //!
 //! let mut vec: Vec<u32> = vec![0, 1, 2, 3];
-//! # #[cfg(not(bittle_shr))]
 //! assert!(vec.iter_ones().eq([32, 65, 96, 97]));
 //! ```
 //!
@@ -108,7 +91,6 @@
 //! vec.set_bit(96);
 //! vec.set_bit(97);
 //! assert!(vec.iter_ones().eq([32, 65, 96, 97]));
-//! # #[cfg(not(bittle_shr))]
 //! assert_eq!(vec, [0, 1, 2, 3]);
 //! ```
 //!
@@ -163,11 +145,14 @@
 //! <br>
 //!
 //! [`Bits::join_ones`]: https://docs.rs/bittle/latest/bittle/trait.Bits.html#method.join_ones
+//! [`Bits::test_bit_shr`]: https://docs.rs/bittle/latest/bittle/trait.Bits.html#method.test_bit_shr
+//! [`Bits::test_bit_with`]: https://docs.rs/bittle/latest/bittle/trait.Bits.html#method.test_bit_with
 //! [`Bits`]: https://docs.rs/bittle/latest/bittle/trait.Bits.html
 //! [`BitsMut`]: https://docs.rs/bittle/latest/bittle/trait.BitsMut.html
 //! [`BitsOwned`]: https://docs.rs/bittle/latest/bittle/trait.BitsOwned.html
 //! [`Copy`]: https://doc.rust-lang.org/std/marker/trait.Copy.html
 //! [`set!`]: https://docs.rs/bittle/latest/bittle/macro.set.html
+//! [`Shl`]: https://docs.rs/bittle/latest/bittle/struct.shl.html
 //! [`u32`]: https://doc.rust-lang.org/std/primitive.u32.html
 //! [see issue #2]: https://github.com/udoprog/bittle/pull/2
 
@@ -196,6 +181,9 @@ pub use self::bits_mut::BitsMut;
 
 mod bits_owned;
 pub use self::bits_owned::BitsOwned;
+
+mod shift;
+pub use self::shift::{DefaultShift, Shl, Shr};
 
 pub mod prelude {
     //! Prelude use to conveniently import all relevant bits-oriented traits.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,5 @@
-/// Construct a bit set with specific values set.
+/// Construct a bit set with specific values set using the default shift
+/// indexing.
 ///
 /// # Examples
 ///
@@ -7,9 +8,6 @@
 ///
 /// let mask: u8 = bittle::set![0, 1, 3];
 /// assert!(mask.iter_ones().eq([0, 1, 3]));
-/// # #[cfg(bittle_shr)]
-/// # assert_eq!(mask, 0b11010000);
-/// # #[cfg(not(bittle_shr))]
 /// assert_eq!(mask, 0b00001011);
 /// ```
 #[macro_export]
@@ -17,6 +15,28 @@ macro_rules! set {
     ($($index:expr),* $(,)?) => {{
         let mut set = $crate::BitsOwned::ZEROS;
         $($crate::BitsMut::set_bit(&mut set, $index);)*
+        set
+    }};
+}
+
+/// Construct a bit set with specific values set with [`Shr`].
+///
+/// [`Shr`]: crate::Shr
+///
+/// # Examples
+///
+/// ```
+/// use bittle::Bits;
+///
+/// let mask: u8 = bittle::set_shr![0, 1, 3];
+/// assert!(mask.iter_ones_shr().eq([0, 1, 3]));
+/// assert_eq!(mask, 0b11010000);
+/// ```
+#[macro_export]
+macro_rules! set_shr {
+    ($($index:expr),* $(,)?) => {{
+        let mut set = $crate::BitsOwned::ZEROS;
+        $($crate::BitsMut::set_bit_with::<$crate::Shr>(&mut set, $index);)*
         set
     }};
 }

--- a/src/shift.rs
+++ b/src/shift.rs
@@ -1,0 +1,206 @@
+//! Traits for dealing with shift ordering.
+
+use crate::number::Number;
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Shl {}
+    impl Sealed for super::Shr {}
+}
+
+/// Trait governing how a shift operation is performed over a number.
+pub trait Shift: 'static + self::sealed::Sealed {
+    /// Generate an overflowing mask for the given index.
+    fn mask<T>(index: u32) -> T
+    where
+        T: Number;
+
+    /// Generate a reverse overflowing mask at the given index, that is at
+    /// the `BITS - index - 1` bit location.
+    fn mask_rev<T>(index: u32) -> T
+    where
+        T: Number;
+
+    /// Count the number of "leading" ones.
+    fn ones<T>(value: T) -> u32
+    where
+        T: Number;
+
+    /// Count the number of "trailing" ones.
+    fn ones_rev<T>(value: T) -> u32
+    where
+        T: Number;
+
+    /// Count the number of "leading" zeros.
+    fn zeros<T>(value: T) -> u32
+    where
+        T: Number;
+
+    /// Count the number of "trailing" zeros.
+    fn zeros_rev<T>(value: T) -> u32
+    where
+        T: Number;
+}
+
+/// Shift-left indexing for bit sets.
+///
+/// This can be used in combination with methods such as
+/// [`Bits::test_bit_with`].
+///
+/// Shift-left indexing is constructed increasingly from right to left for
+/// individual primitives, such as the following [`u8`] literal:
+///
+/// ```text
+/// 0b0010_0010u8
+///     ^    ^- index 1
+///     '------ index 5
+/// ```
+///
+/// Arrays are treated the same as expected where the index grows from smallest
+/// to largest address, but each interior primitive is indexed using shift left
+/// indexing:
+///
+/// ```text
+///  0 --------- 8  8 -------- 15
+/// [0b0010_0010u8, 0b1000_0000u8]
+///      ^    ^       ^- index 15
+///      |    '--------- index 1
+///      '-------------- index 5
+/// ```
+///
+/// [`Bits::test_bit_with`]: crate::Bits::test_bit_with
+#[non_exhaustive]
+pub struct Shl;
+
+impl Shift for Shl {
+    #[inline]
+    fn mask<T>(index: u32) -> T
+    where
+        T: Number,
+    {
+        T::mask(index)
+    }
+
+    #[inline]
+    fn mask_rev<T>(index: u32) -> T
+    where
+        T: Number,
+    {
+        T::mask_rev(index)
+    }
+
+    #[inline]
+    fn ones<T>(value: T) -> u32
+    where
+        T: Number,
+    {
+        value.ones()
+    }
+
+    #[inline]
+    fn ones_rev<T>(value: T) -> u32
+    where
+        T: Number,
+    {
+        value.ones_rev()
+    }
+
+    #[inline]
+    fn zeros<T>(value: T) -> u32
+    where
+        T: Number,
+    {
+        value.zeros()
+    }
+
+    #[inline]
+    fn zeros_rev<T>(value: T) -> u32
+    where
+        T: Number,
+    {
+        value.zeros_rev()
+    }
+}
+
+/// Shift-right indexing for bit sets.
+///
+/// This can be used in combination with methods such as
+/// [`Bits::test_bit_with`].
+///
+/// Shift-right indexing is constructed increasingly from left to right for
+/// individual primitives, such as the following [`u8`] literal:
+///
+/// ```text
+/// 0b0010_0010u8
+///     ^    ^- index 6
+///     '------ index 2
+/// ```
+///
+/// Arrays are treated the same as expected where the index grows from smallest
+/// to largest address:
+///
+/// ```text
+///  0 --------- 8  8 -------- 15
+/// [0b0010_0010u8, 0b1000_0000u8]
+///      ^    ^       ^- index 8
+///      |    '--------- index 6
+///      '-------------- index 2
+/// ```
+///
+/// [`Bits::test_bit_with`]: crate::Bits::test_bit_with
+#[non_exhaustive]
+pub struct Shr;
+
+impl Shift for Shr {
+    #[inline]
+    fn mask<T>(index: u32) -> T
+    where
+        T: Number,
+    {
+        T::mask_rev(index)
+    }
+
+    #[inline]
+    fn mask_rev<T>(index: u32) -> T
+    where
+        T: Number,
+    {
+        T::mask(index)
+    }
+
+    #[inline]
+    fn ones<T>(value: T) -> u32
+    where
+        T: Number,
+    {
+        value.ones_rev()
+    }
+
+    #[inline]
+    fn ones_rev<T>(value: T) -> u32
+    where
+        T: Number,
+    {
+        value.ones()
+    }
+
+    #[inline]
+    fn zeros<T>(value: T) -> u32
+    where
+        T: Number,
+    {
+        value.zeros_rev()
+    }
+
+    #[inline]
+    fn zeros_rev<T>(value: T) -> u32
+    where
+        T: Number,
+    {
+        value.zeros()
+    }
+}
+
+/// The default shift index in use.
+#[allow(clippy::module_name_repetitions)]
+pub type DefaultShift = Shl;


### PR DESCRIPTION
Solves #6

This introduces a new suite of methods while maintaining the existing ones as a default behavior.

The new suite of methods and behaviors are:
* The `Set` type can be generically constructed with a custom shift indexing either through the `set!` macro or using the `Set::new_with` constructor.
* A new `bittle::set_shr!` has been introduces to explicitly build sets with shift-right indexing.
* Right-shift indexing can be explicitly used with a new family of methods where it's appropriate using names suffixed with `*_shr`.
* Generic shift indexing can be used with a new family of methods where it's appropriate using names suffixed with `*_with`. These take a generic argument which must be one of the following newly introduces types: `DefaultShift`, `Shl` (for shift-left indexing), or `Shr` (for shift-right indexing).